### PR TITLE
Avoid testing python-nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 python:
 - "2.7"
-- "3.4"
 - "3.5"
-- "nightly"
+- "3.6"
 install:
 - python setup.py install
 script:


### PR DESCRIPTION
The unit tests fail on the nightly Python build.  Let's avoid testing nightly!